### PR TITLE
Add polyphonic aftertouch support

### DIFF
--- a/Source/Conductor.h
+++ b/Source/Conductor.h
@@ -62,6 +62,7 @@ public:
     std::vector<InstrumentInfo> orchestra;
 
     void handleIncomingPitchBend(int channel, int pitchBendValue, const juce::String& pluginId, juce::int64& timestamp);
+    void handleIncomingAftertouch(int channel, int noteNumber, int aftertouchValue, const juce::String& pluginId, juce::int64& timestamp);
 
     // Synchronize the orchestra with the PluginManager
     void syncOrchestraWithPluginManager();


### PR DESCRIPTION
## Summary
- handle incoming OSC `aftertouch` messages and convert them to `MidiMessage::aftertouchChange`
- log polyphonic aftertouch messages by detecting `MidiMessage::isAftertouch`

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b319cf30988325afb2dd4a49d14882