### PR TITLE
Add controls for stripping silence and undoing overdubs

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -46,7 +46,7 @@ MainComponent::MainComponent()
 
 	// Initialize the "Get Recorded" button
 	addAndMakeVisible(getRecordedButton);
-	getRecordedButton.onClick = [this]() { midiManager.getRecorded(); }; // Use lambda for button click handling
+	getRecordedButton.onClick = [this]() { midiManager.getRecorded(); updateOverdubUI(); }; // Use lambda for button click handling
 
 	// Initialize the "List Plugin Instances" button
 	addAndMakeVisible(listPluginInstancesButton);
@@ -81,7 +81,7 @@ MainComponent::MainComponent()
 
 	// Add recording buttons
 	addAndMakeVisible(startRecordingButton);
-	startRecordingButton.onClick = [this]() { midiManager.startRecording(); }; // Use lambda for button click handling
+	startRecordingButton.onClick = [this]() { midiManager.startRecording(); updateOverdubUI(); }; // Use lambda for button click handling
 
 	// Add Project name label
 	addAndMakeVisible(projectNameLabel);
@@ -90,13 +90,23 @@ MainComponent::MainComponent()
 	addAndMakeVisible(moveToEndButton);
 	moveToEndButton.onClick = [this]() { moveSelectedRowsToEnd(); }; // Use lambda for button click handling
 
-    // Initialize the "Start Overdub" button
-    addAndMakeVisible(startOverdubButton);
-    startOverdubButton.onClick = [this]() { midiManager.startOverdub(); updateOverdubUI(); };
+	// Initialize the "Start Overdub" button
+	addAndMakeVisible(startOverdubButton);
+	startOverdubButton.onClick = [this]() { midiManager.startOverdub(); updateOverdubUI(); };
 
-    // Initialize the "Stop Overdub" button
-    addAndMakeVisible(stopOverdubButton);
-    stopOverdubButton.onClick = [this]() { midiManager.stopOverdub(); updateOverdubUI(); };
+	// Initialize the "Stop Overdub" button
+	addAndMakeVisible(stopOverdubButton);
+	stopOverdubButton.onClick = [this]() { midiManager.stopOverdub(); updateOverdubUI(); };
+
+	// Initialize the "Strip Silence" button
+	addAndMakeVisible(stripLeadingSilenceButton);
+	stripLeadingSilenceButton.onClick = [this]() { midiManager.stripLeadingSilence(); updateOverdubUI(); };
+
+	// Initialize the "Undo Overdub" button
+	addAndMakeVisible(undoOverdubButton);
+	undoOverdubButton.onClick = [this]() { midiManager.undoLastOverdub(); updateOverdubUI(); };
+
+	updateOverdubUI();
 }
 
 void MainComponent::resized()
@@ -165,6 +175,8 @@ void MainComponent::resized()
 	int row4Y = row3Y - buttonHeight - spacingY;
 	startOverdubButton.setBounds(margin, row4Y, buttonWidth, buttonHeight);
 	stopOverdubButton.setBounds(startOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+	stripLeadingSilenceButton.setBounds(stopOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+	undoOverdubButton.setBounds(stripLeadingSilenceButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
 
 
 
@@ -195,6 +207,9 @@ void MainComponent::updateOverdubUI()
         startOverdubButton.setColour(juce::TextButton::buttonColourId, juce::Colours::lightgrey);
         stopOverdubButton.setColour(juce::TextButton::buttonColourId, juce::Colours::lightgrey);
     }
+
+    stripLeadingSilenceButton.setEnabled(!midiManager.isOverdubbing && midiManager.hasRecordedEvents());
+    undoOverdubButton.setEnabled(!midiManager.isOverdubbing && midiManager.canUndoOverdub());
 }
 void MainComponent::handleAudioPortChange()
 {

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -228,6 +228,8 @@ private:
 	// Buttons for overdub control
     juce::TextButton startOverdubButton { "Start Overdub" };
     juce::TextButton stopOverdubButton { "Stop Overdub" };
+    juce::TextButton stripLeadingSilenceButton { "Strip Silence" };
+    juce::TextButton undoOverdubButton { "Undo Overdub" };
 
 	PluginManager pluginManager { this, midiCriticalSection, midiBuffer }; // Create an instance of the PluginManager class
 	Conductor conductor{ pluginManager, midiManager, this }; // Create an instance of the Conductor class

--- a/Source/MidiManager.h
+++ b/Source/MidiManager.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <JuceHeader.h>
+#include <vector>
 
 class MainComponent; // Forward declaration
 
@@ -27,9 +28,14 @@ public:
 	void closeMidiInput();
 	void startOverdub();
 	void stopOverdub();
+	void stripLeadingSilence();
+	void undoLastOverdub();
 	void getRecorded();
 	void startRecording();
 	void sendTestNote();
+
+	bool canUndoOverdub() const;
+	bool hasRecordedEvents() const;
 
 	// Declaration of the function to process recorded MIDI
 	void processRecordedMidi();
@@ -59,6 +65,11 @@ private:
 	juce::MidiBuffer& incomingMidi; // MIDI Buffer to store incoming MIDI messages
 
 	MainComponent* mainComponent; // Pointer to the MainComponent
+
+	std::vector<juce::MidiBuffer> overdubHistory;
+
+	static juce::int64 getTimestampFromEvent(const juce::MidiMessage& message, int samplePosition);
+	void republishRecordedEvents(const juce::MidiBuffer& bufferCopy);
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MidiManager)
 };


### PR DESCRIPTION
## Summary
- add UI buttons to strip leading silence and undo overdubs and update their layout/state handling
- extend MidiManager with overdub history management, strip leading silence, and helper queries for the UI
- refresh the overdub UI state after recording actions to keep the new controls in sync

## Testing
- Not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d445904c2c83259de56840aea46216