### PR TITLE
Skip known VST3 files during add scans

### DIFF
--- a/Source/PluginManager.cpp
+++ b/Source/PluginManager.cpp
@@ -1477,8 +1477,25 @@ void PluginManager::scanPlugins(juce::FileSearchPath searchPaths, bool replaceEx
     const auto pluginFiles = vst3Format.searchPathsForPlugins(searchPaths, true, false);
 
     juce::OwnedArray<juce::PluginDescription> typesFound;
+    const auto knownTypes = knownPluginList.getTypes();
     for (const auto &path : pluginFiles)
     {
+        if (!replaceExisting)
+        {
+            const auto isAlreadyKnown = [&knownTypes, &path]()
+            {
+                for (const auto &knownType : knownTypes)
+                {
+                    if (knownType.fileOrIdentifier == path)
+                        return true;
+                }
+                return false;
+            }();
+
+            if (isAlreadyKnown)
+                continue;
+        }
+
         if (!replaceExisting && knownPluginList.isListingUpToDate(path, vst3Format))
             continue;
 


### PR DESCRIPTION
### Motivation
- When running `scanPlugins` in add mode, avoid re-opening VST3 files already recorded in `knownPluginList` to speed up scans and prevent duplicates.

### Description
- In `Source/PluginManager.cpp` inside `PluginManager::scanPlugins` fetch `knownPluginList.getTypes()` and skip plugin files whose `fileOrIdentifier` matches the scanned `path` when `replaceExisting` is false.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69696b9b3780832588e69ea1de609213)